### PR TITLE
Wait so we can kill if migrations take forever

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -60,10 +60,10 @@ if('function' !== typeof global.Promise) {
   global.Promise = require('promise');
 }
 
-function wait(connection) {
+function wait(connection, options) {
   if(!requiresWait) { return; }
   debug('Waiting for', MIGRATION_TABLE_NAME, 'to be ready for writes');
-  return r.wait([{waitFor: 'ready_for_writes'}]).run(connection);
+  return r.wait([{waitFor: 'ready_for_writes', timeout: options.timeout}]).run(connection);
 }
 
 /*
@@ -80,7 +80,9 @@ function getConfig(root) {
   var config = {
     host: nconf.get('host'),
     port: nconf.get('port'),
-    db: nconf.get('db')
+    db: nconf.get('db'),
+    discovery: nconf.get('discovery') || false,
+    timeout: nconf.get('timeout') || (5 * 60)
   };
   return Promise.resolve(config);
 }
@@ -108,7 +110,7 @@ function connectToDb(config) {
         .then(function () {
           debug('Use', config.db);
           connection.use(config.db);
-          return wait(connection);
+          return wait(connection, config);
         })
         .then(function () {
           return connection;

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -81,7 +81,7 @@ function getConfig(root) {
     host: nconf.get('host'),
     port: nconf.get('port'),
     db: nconf.get('db'),
-    discovery: nconf.get('discovery') || false,
+    discovery: Boolean(nconf.get('discovery')) || false,
     timeout: nconf.get('timeout') || (5 * 60)
   };
   return Promise.resolve(config);

--- a/test/database.json
+++ b/test/database.json
@@ -1,5 +1,7 @@
 {
   "host": "localhost",
   "port": 28015,
-  "db": "_migrations_integration_tests"
+  "db": "_migrations_integration_tests",
+  "discovery": true,
+  "timeout": 60
 }


### PR DESCRIPTION
Set wait to 5 minutes default, otherwise in the timeout config.
