### PR TITLE
fix getCompletedMigrations(): return the expected list of migrations

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -145,7 +145,15 @@ function getCompletedMigrations(connection) {
   debug('Read completed migrations');
   return ensureMigrationsTable(connection)
     .then(function () {
-      return r.table(MIGRATION_TABLE_NAME).orderBy({index: 'timestamp'}).run(connection);
+      return r.table(MIGRATION_TABLE_NAME)
+        .orderBy({index: 'timestamp'})
+        .run(connection)
+        .then(function (cursor) {
+          return cursor.toArray()
+            .then(function (results) {
+              return results
+            })
+        })
     });
 }
 
@@ -331,7 +339,7 @@ function debug() {
 
 function logInfo() {
   if(levels.indexOf(logLevel) > levels.indexOf('info')) { return; }
-  
+
   var args = Array.prototype.slice.call(arguments);
   args.unshift(chalk.blue('[rethink-migrate]'));
   console.log(args.join(' '));


### PR DESCRIPTION
There seemed to be a bug in `getCompletedMigrations()` such that it was returning another promise rather than the expected list of migrations. This PR should fix that.
