### PR TITLE
support authKey in config (for production deployments)

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -80,7 +80,8 @@ function getConfig(root) {
   var config = {
     host: nconf.get('host'),
     port: nconf.get('port'),
-    db: nconf.get('db')
+    db: nconf.get('db'),
+    authKey: nconf.get('authKey')
   };
   return Promise.resolve(config);
 }
@@ -331,7 +332,7 @@ function debug() {
 
 function logInfo() {
   if(levels.indexOf(logLevel) > levels.indexOf('info')) { return; }
-  
+
   var args = Array.prototype.slice.call(arguments);
   args.unshift(chalk.blue('[rethink-migrate]'));
   console.log(args.join(' '));

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -81,7 +81,8 @@ function getConfig(root) {
     host: nconf.get('host'),
     port: nconf.get('port'),
     db: nconf.get('db'),
-    authKey: nconf.get('authKey')
+    authKey: nconf.get('authKey'),
+    ssl: nconf.get('ssl')
   };
   return Promise.resolve(config);
 }


### PR DESCRIPTION
It's likely that the `authKey` configuration parameter may be needed in production deployments. This PR solves that.
