### PR TITLE
Enable passing an options object to `config.ssl`

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -74,6 +74,10 @@ function getConfig(root) {
     .argv()
     .env()
     .file({ file: path.join(root, 'database.json') });
+
+  var ssl = nconf.get('ssl');
+  ssl = (typeof ssl === 'undefined') ? false : JSON.parse(ssl);
+
   var config = {
     host: nconf.get('host'),
     port: nconf.get('port'),
@@ -81,7 +85,7 @@ function getConfig(root) {
     discovery: Boolean(nconf.get('discovery')) || false,
     timeout: nconf.get('timeout') || (5 * 60),
     authKey: nconf.get('authKey'),
-    ssl: nconf.get('ssl')
+    ssl: ssl
   };
   return Promise.resolve(config);
 }


### PR DESCRIPTION
You'll notice that according to the rethinkdbdash README.md (line 170-171)

> `ssl` may also be an object that will be passed as the `options`
> argument to `tls.connect`

https://github.com/neumino/rethinkdbdash/blame/master/README.md#L170-171

This modification enables passing an object via a JSON string, while
continuing to support simple truthy/falsy values.
