### PR TITLE
Read configuration from rethink-migrate-file.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,18 @@ or
 npm install --save rethinkdbdash
 ```
 
-Create a ```database.json``` file in the root of your solution with the format:
+Create a ```rethink-migrate-file.js``` with the format:
+```javascript
+module.exports = {
+  "host": "localhost",
+  "port": 28015,
+  "db": "migrations",
+  "discovery": true,
+  "timeout": 60
+}
+```
+
+Or if you prefere, you can create a ```database.json``` file in the root of your solution with the format:
 
 ```json
 {
@@ -42,6 +53,12 @@ Create a ```database.json``` file in the root of your solution with the format:
 Other, optional, parameters are ```authKey``` and ```ssl```.
 
 You can also use environment variables or arguments to override.
+
+The configuration precedence is:
+ - arguments
+ - environment variables
+ - database.json
+ - rethink-migrate-file.js
 
 ### Log levels
 

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -68,12 +68,15 @@ function wait(connection, options) {
   - arguments
   - environment variables
   - /database.json
+  - /rethink-mgrate-file.js
  */
 function getConfig(root) {
   nconf
     .argv()
     .env()
-    .file({ file: path.join(root, 'database.json') });
+    .file({ file: path.join(root, 'database.json') })
+    .defaults(getConfigFromRethinkMigrateFile(root));
+
   var config = {
     host: nconf.get('host'),
     port: nconf.get('port'),
@@ -84,6 +87,21 @@ function getConfig(root) {
     ssl: nconf.get('ssl')
   };
   return Promise.resolve(config);
+}
+
+/*
+  Read config from /rethink-migrate-file.js.
+
+  Returns an empty object if the file couldn't be loaded.
+ */
+function getConfigFromRethinkMigrateFile(root) {
+  var config = {};
+
+  try {
+    config = require(path.join(root, 'rethink-migrate-file'));
+  } catch(e) {}
+
+  return config
 }
 
 /*


### PR DESCRIPTION
Following the same idea as `knex` so you could have:

``` javascript
require('dotenv').config();

module.exports = {
  host: process.env.RETHINK_HOST,
  port: process.env.RETHINK_PORT,
  db: process.env.RETHINK_DB
};
```
