### PR TITLE
Throw migation errors up to rethink-migrate script

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -278,6 +278,7 @@ function migrateUp(params) {
     })
     .catch(function (error) {
       logError('Migration failed', error);
+      throw error;
     });
 }
 
@@ -324,6 +325,7 @@ function migrateDown(params) {
     })
     .catch(function (error) {
       logError('Migration failed', error);
+      throw error;
     });
 }
 


### PR DESCRIPTION
Throwing errors allow the main process to exit with status = 1, this
is useful if you, for example, want to abort a chain of commands if
the migrate command failed for some reason.