### PR TITLE
Fix for env vars not coming through from dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@ A migration tool for rethink db
 
 ## Changes
 
+- v2.0.0: major rev to how config works.  multiple breaking changes see updated README
 - v1.3.0: fixed an exception if there are no migrations to revert on migrate down
 - v1.2.2: changed signature for the migrations to support the rethinkdbdash driver
-
-
 
 ## Install
 
@@ -36,12 +35,12 @@ Create a ```database.json``` file in the root of your solution with the format:
   "host": "localhost",
   "port": 28015,
   "db": "foo",
-  "timeout": 60
-  "authKey": "bar" (optional)
+  "timeout": 60,
+  "authKey": "bar"
 }
 ```
 ### Environment Variables
-(uses the dotenv module)
+(uses the dotenv module to pull in a .env if its there)
 
 RETHINK_HOST=localhost
 RETHINK_PORT=28015

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # rethink-migrate
 A migration tool for rethink db
 
-## Version 1.2
+## Changes
 
-Breaking change: In order to support rethinkdbdash, the format of the migrations has
-been changed from
-```exports.up = function (connection) {``` and ```exports.down = function (connection) {```
-to
-```exports.up = function (r, connection) {``` and ```exports.down = function (r, connection) {```
+- v1.3.0: fixed an exception if there are no migrations to revert on migrate down
+- v1.2.2: changed signature for the migrations to support the rethinkdbdash driver
+
+
 
 ## Install
 
@@ -27,21 +26,28 @@ or
 npm install --save rethinkdbdash
 ```
 
+## Configuration
+
+### File
 Create a ```database.json``` file in the root of your solution with the format:
 
 ```json
 {
   "host": "localhost",
   "port": 28015,
-  "db": "migrations",
-  "discovery": true,
+  "db": "foo",
   "timeout": 60
+  "authKey": "bar" (optional)
 }
 ```
+### Environment Variables
+(uses the dotenv module)
 
-Other, optional, parameters are ```authKey``` and ```ssl```.
-
-You can also use environment variables or arguments to override.
+RETHINK_HOST=localhost
+RETHINK_PORT=28015
+RETHINK_DB=foo
+RETHINK_TIMEOUT=60
+RETHINK_AUTHKEY=bar
 
 ### Log levels
 

--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ A migration tool for rethink db
 
 ## Install
 
-```npm install -g rethink-migrate```
+`npm install -g rethink-migrate`
 
 ## Setup
 
 Install a rethinkdb driver:
 
-```bash
+`
 npm install --save rethinkdb
-```
+`
 
 or
 
-```bash
+`
 npm install --save rethinkdbdash
-```
+`
 
 ## Configuration
 
@@ -42,11 +42,11 @@ Create a ```database.json``` file in the root of your solution with the format:
 ### Environment Variables
 (uses the dotenv module to pull in a .env if its there)
 
-RETHINK_HOST=localhost
-RETHINK_PORT=28015
-RETHINK_DB=foo
-RETHINK_TIMEOUT=60
-RETHINK_AUTHKEY=bar
+RETHINK_HOST=localhost <br/>
+RETHINK_PORT=28015 <br/>
+RETHINK_DB=foo <br/>
+RETHINK_TIMEOUT=60 <br/>
+RETHINK_AUTHKEY=bar <br/>
 
 ### Log levels
 

--- a/bin/rethink-migrate
+++ b/bin/rethink-migrate
@@ -18,6 +18,7 @@ var cli = meow([
     'Options:',
     ' -l, --logLevel  debug | info | warning | error | none',
     ' -r, --root      Specify file root',
+    ' -e, --env       development | sandbox | production',
     '',
     'Create a new migration script',
     '  $ rethink-migrate create [migration name]'
@@ -26,7 +27,8 @@ var cli = meow([
     alias: {
         a: 'all',
         l: 'logLevel',
-        r: 'root'
+        r: 'root',
+        e: 'env'
     }
   });
 
@@ -36,7 +38,8 @@ var path = cli.flags.root ? path.resolve(cli.flags.root) : process.cwd();
 if(command === 'up' || command === 'down') {
   var all = cli.flags.all;
   var logLevel = cli.flags.logLevel || 'info';
-  return migrate[command]({all: all, logLevel: logLevel, root: path})
+  var environment = cli.flags.e
+  return migrate[command]({all: all, logLevel: logLevel, root: path, env: environment })
     .then(function (result) {
       process.exit(0);
     })
@@ -58,7 +61,7 @@ if(command === 'up' || command === 'down') {
       process.exit(1);
     });
 } else {
-  console.log('unknown command');
+  console.log(cli.help);
   process.exit(1);
 }
 

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -3,8 +3,9 @@ var r,
   path = require('path'),
   chalk = require('chalk'),
   nconf = require('nconf'),
-  dotenv = require('dotenv');
   _ = require('lodash');
+
+require("dotenv").load({ path: "./.env-defaults" });
 
 var MIGRATION_TABLE_NAME = '_migrations';
 

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -3,6 +3,7 @@ var r,
   path = require('path'),
   chalk = require('chalk'),
   nconf = require('nconf'),
+  dotenv = require('dotenv');
   _ = require('lodash');
 
 var MIGRATION_TABLE_NAME = '_migrations';
@@ -69,20 +70,26 @@ function wait(connection, options) {
   - environment variables
   - /database.json
  */
-function getConfig(root) {
+function getConfig(root, env) {
+  dotenv.load({
+    silent: true
+  });
   nconf
-    .argv()
-    .env()
+    .env("_")
     .file({ file: path.join(root, 'database.json') });
-  var config = {
-    host: nconf.get('host'),
-    port: nconf.get('port'),
-    db: nconf.get('db'),
-    discovery: Boolean(nconf.get('discovery')) || false,
-    timeout: nconf.get('timeout') || (5 * 60),
-    authKey: nconf.get('authKey'),
-    ssl: nconf.get('ssl')
+  var config;
+  config = {
+    host: nconf.get("RETHINK:HOST"),
+    port: nconf.get("RETHINK:PORT") || 28015,
+    db: nconf.get("RETHINK:DB"),
+    timeout: nconf.get("RETHINK:TIMEOUT") || 60,
+    authKey: nconf.get("RETHINK:AUTHKEY")
   };
+  if (!config.host && !config.db) {
+    debug("env not found, falling back to database.json");
+    config = nconf.get(env);
+  }
+  console.log(env, " : ", config);
   return Promise.resolve(config);
 }
 
@@ -236,10 +243,11 @@ function migrateUp(params) {
   params = params || {};
   logLevel = params.logLevel || 'info';
   var root = params.root || process.cwd();
+  var env = params.env || "development";
   var config;
 
   logInfo('Connecting to database');
-  return getConfig(root)
+  return getConfig(root, env)
     .then(function (_config) {
       config = _config;
       debug('config', JSON.stringify(config));
@@ -288,9 +296,10 @@ function migrateDown(params) {
   params = params || {};
   logLevel = params.logLevel || 'info';
   var root = params.root || process.cwd();
+  var env = params.env || "development";
 
   logInfo('Connecting to database');
-  return getConfig(root)
+  return getConfig(root, env)
     .then(function (config) {
       return connectToDb(config);
     })

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -300,6 +300,7 @@ function migrateDown(params) {
         .then(function (completedMigrations) {
           if(!completedMigrations || !completedMigrations.length) {
             logWarning('No migrations to run');
+            return;
           }
 
           var migrationsToRollBack = (params.all) ? completedMigrations.reverse() : [completedMigrations[completedMigrations.length -1]];

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -71,24 +71,19 @@ function wait(connection, options) {
   - /database.json
  */
 function getConfig(root, env) {
-  dotenv.load({
-    silent: true
-  });
+  var defaults = require(path.join(root, 'database.json'));
+  defaults = defaults[env] || {};
   nconf
     .env("_")
-    .file({ file: path.join(root, 'database.json') });
-  var config;
-  config = nconf.get(env);
-  if (!config) {
-    config = {
-      host: nconf.get("RETHINK:HOST"),
-      port: nconf.get("RETHINK:PORT") || 28015,
-      db: nconf.get("RETHINK:DB"),
-      timeout: nconf.get("RETHINK:TIMEOUT") || 300,
-      authKey: nconf.get("RETHINK:AUTHKEY")
-    };
-  }
-  console.log(env, " : ", config);
+    .defaults(defaults);
+  var config = {
+    host: nconf.get("RETHINK:HOST"),
+    port: nconf.get("RETHINK:PORT") || 28015,
+    db: nconf.get("RETHINK:DB"),
+    timeout: nconf.get("RETHINK:TIMEOUT") || 300,
+    authKey: nconf.get("RETHINK:AUTHKEY")
+  };
+  logInfo('Using config:', chalk.yellow(JSON.stringify(config, null, 2)));
   return Promise.resolve(config);
 }
 

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -285,6 +285,7 @@ function migrateUp(params) {
     })
     .catch(function (error) {
       logError('Migration failed', error);
+      throw error;
     });
 }
 
@@ -333,6 +334,7 @@ function migrateDown(params) {
     })
     .catch(function (error) {
       logError('Migration failed', error);
+      throw error;
     });
 }
 

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -78,16 +78,15 @@ function getConfig(root, env) {
     .env("_")
     .file({ file: path.join(root, 'database.json') });
   var config;
-  config = {
-    host: nconf.get("RETHINK:HOST"),
-    port: nconf.get("RETHINK:PORT") || 28015,
-    db: nconf.get("RETHINK:DB"),
-    timeout: nconf.get("RETHINK:TIMEOUT") || 60,
-    authKey: nconf.get("RETHINK:AUTHKEY")
-  };
-  if (!config.host && !config.db) {
-    debug("env not found, falling back to database.json");
-    config = nconf.get(env);
+  config = nconf.get(env);
+  if (!config) {
+    config = {
+      host: nconf.get("RETHINK:HOST"),
+      port: nconf.get("RETHINK:PORT") || 28015,
+      db: nconf.get("RETHINK:DB"),
+      timeout: nconf.get("RETHINK:TIMEOUT") || 300,
+      authKey: nconf.get("RETHINK:AUTHKEY")
+    };
   }
   console.log(env, " : ", config);
   return Promise.resolve(config);
@@ -243,7 +242,7 @@ function migrateUp(params) {
   params = params || {};
   logLevel = params.logLevel || 'info';
   var root = params.root || process.cwd();
-  var env = params.env || "development";
+  var env = params.env || "default";
   var config;
 
   logInfo('Connecting to database');
@@ -296,7 +295,7 @@ function migrateDown(params) {
   params = params || {};
   logLevel = params.logLevel || 'info';
   var root = params.root || process.cwd();
-  var env = params.env || "development";
+  var env = params.env || "default";
 
   logInfo('Connecting to database');
   return getConfig(root, env)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rethink-migrate",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "A migration tool for rethink db",
   "main": "lib/migrate",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "bin": "./bin/rethink-migrate",
   "dependencies": {
     "chalk": "^1.1.1",
+    "dotenv": "^2.0.0",
     "lodash": "^3.10.1",
     "meow": "^3.4.1",
     "moment": "^2.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rethink-migrate",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "A migration tool for rethink db",
   "main": "lib/migrate",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rethink-migrate",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A migration tool for rethink db",
   "main": "lib/migrate",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socialtables/rethink-migrate",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A migration tool for rethink db",
   "main": "lib/migrate",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rethink-migrate",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "A migration tool for rethink db",
   "main": "lib/migrate",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rethink-migrate",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A migration tool for rethink db",
   "main": "lib/migrate",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rethink-migrate",
+  "name": "@socialtables/rethink-migrate",
   "version": "2.1.0",
   "description": "A migration tool for rethink db",
   "main": "lib/migrate",


### PR DESCRIPTION
The dotenv module was loaded but not used, and as such env variables were not getting passed into the migrate functions.  This PR addresses that.