### PR TITLE
Update readme, migration syntax is wrong in read me.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ exports.down = function (r, connection) {
 ```
 ## Run migrations
 
-```rethink migrate up``` will run all outstanding up migrations.
+```rethink-migrate up``` will run all outstanding up migrations.
 
-```rethink migrate down``` will run one down migration.
+```rethink-migrate down``` will run one down migration.
 
-```rethink migrate down --all``` will run all outstanding down migrations.
+```rethink-migrate down --all``` will run all outstanding down migrations.
 
 ### Options
 


### PR DESCRIPTION
Update to readme, migration syntax in command-line/shell is wrong. Kind of confusing as is.